### PR TITLE
allow ntfs-formatted devices to be listed and selectable as target drive

### DIFF
--- a/src/unetbootin/unetbootin.cpp
+++ b/src/unetbootin/unetbootin.cpp
@@ -573,7 +573,7 @@ QStringList unetbootin::listsanedrives()
                     {
 						if (!volidcommand.isEmpty())
 						{
-							if (QString(callexternapp(volidcommand, QString("-t %2").arg(usbfileinfoL.at(i).canonicalFilePath()))).contains(QRegExp("(vfat|ext2|ext3|ext4)")))
+							if (QString(callexternapp(volidcommand, QString("-t %2").arg(usbfileinfoL.at(i).canonicalFilePath()))).contains(QRegExp("(vfat|ext2|ext3|ext4|ntfs)")))
 								fulldrivelist.append(usbfileinfoL.at(i).canonicalFilePath());
 						}
 						else
@@ -581,7 +581,7 @@ QStringList unetbootin::listsanedrives()
 							QString tstrblk = QString(callexternapp(blkidcommand, QString("-s TYPE %2").arg(usbfileinfoL.at(i).canonicalFilePath())));
 							if (tstrblk.contains('='))
 							{
-								if (tstrblk.section('=', -1, -1).remove('"').contains(QRegExp("(vfat|ext2|ext3|ext4)")))
+								if (tstrblk.section('=', -1, -1).remove('"').contains(QRegExp("(vfat|ext2|ext3|ext4|ntfs)")))
 									fulldrivelist.append(usbfileinfoL.at(i).canonicalFilePath());
 							}
 						}


### PR DESCRIPTION
(as I outlined a proposed fix in comment #1, a while back, here:
https://bugs.launchpad.net/unetbootin/+bug/1125219 )
