### PR TITLE
Add support for Ubuntu 13.10

### DIFF
--- a/src/unetbootin/distrolst.cpp
+++ b/src/unetbootin/distrolst.cpp
@@ -18,8 +18,10 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 #ifndef ubunturelnamereplace
 #define ubunturelnamereplace \
 	relname \
-    .replace("13.04", "raring") \
-    .replace("12.10", "quantal") \
+	.replace("14.04", "trusty") \
+	.replace("13.10", "saucy") \
+	.replace("13.04", "raring") \
+	.replace("12.10", "quantal") \
 	.replace("12.04", "precise") \
 	.replace("11.10", "oneiric") \
 	.replace("11.04", "natty") \

--- a/src/unetbootin/distrover.cpp
+++ b/src/unetbootin/distrover.cpp
@@ -12,6 +12,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 "12.04_NetInstall" << "12.04_NetInstall_x64" << "12.04_HdMedia" << "12.04_HdMedia_x64" << "12.04_Live" << "12.04_Live_x64" << \
 "12.10_NetInstall" << "12.10_NetInstall_x64" << "12.10_HdMedia" << "12.10_HdMedia_x64" << "12.10_Live" << "12.10_Live_x64" << \
 "13.04_NetInstall" << "13.04_NetInstall_x64" << "13.04_HdMedia" << "13.04_HdMedia_x64" << "13.04_Live" << "13.04_Live_x64" << \
+"13.10_NetInstall" << "13.10_NetInstall_x64" << "13.10_HdMedia" << "13.10_HdMedia_x64" << "13.10_Live" << "13.10_Live_x64" << \
 "Daily_Live" << "Daily_Live_x64"
 #endif
 


### PR DESCRIPTION
- Added Ubuntu 13.10 images support;
- Added 13.10 and 14.04 codenames to replace list;
- Fixed indentation.
