### PR TITLE
Remove feature to reboot system after USB is made.

### DIFF
--- a/src/unetbootin/unetbootin.cpp
+++ b/src/unetbootin/unetbootin.cpp
@@ -878,11 +878,6 @@ void unetbootin::on_fexitbutton_clicked()
 	close();
 }
 
-void unetbootin::on_frebootbutton_clicked()
-{
-	sysreboot();
-}
-
 QString unetbootin::displayfisize(quint64 fisize)
 {
 	if (fisize < 10000)
@@ -2718,8 +2713,6 @@ void unetbootin::showDownloadFailedScreen(const QString &fileurl)
 	rebootlayer->setEnabled(true);
 	rebootlayer->show();
 	rebootmsgtext->setText(tr("Download of %1 %2 from %3 failed. Please try downloading the ISO file from the website directly and supply it via the diskimage option.").arg(nameDistro).arg(nameVersion).arg(fileurl));
-	this->frebootbutton->setEnabled(false);
-	this->frebootbutton->hide();
 	this->downloadFailed = true;
 	if (exitOnCompletion)
 	{
@@ -2910,25 +2903,6 @@ QPair<QString, int> unetbootin::filterBestMatch(QStringList ufStringList, QList<
 	return qMakePair(hRegxMatchString, hRegxMatch);
 }
 
-void unetbootin::sysreboot()
-{
-	#ifdef Q_OS_WIN32
-	HANDLE hToken;
-	TOKEN_PRIVILEGES tkp;
-	OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken);
-	LookupPrivilegeValue(NULL, SE_SHUTDOWN_NAME, &tkp.Privileges[0].Luid);
-	tkp.PrivilegeCount = 1;
-	tkp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-	AdjustTokenPrivileges(hToken, FALSE, &tkp, 0, (PTOKEN_PRIVILEGES)NULL, 0);
-	ExitWindowsEx(EWX_REBOOT, EWX_FORCE);
-	#endif
-	#ifdef Q_OS_LINUX
-	callexternapp("init", "6 &");
-	#endif
-#ifdef Q_OS_MAC
-callexternapp("shutdown", "-r now &");
-#endif
-}
 
 QString unetbootin::callexternapp(QString xexecFile, QString xexecParm)
 {
@@ -4324,17 +4298,15 @@ void unetbootin::fininstall()
 	sdesc4->setText(QString("<b>%1 %2</b>").arg(sdesc4->text()).arg(trcurrent));
 	if (installType == tr("Hard Disk"))
 	{
-		rebootmsgtext->setText(tr("After rebooting, select the "UNETBOOTINB" menu entry to boot.%1\nReboot now?").arg(postinstmsg));
+		rebootmsgtext->setText(tr("After rebooting, select the "UNETBOOTINB" menu entry to boot.%1").arg(postinstmsg));
 	}
 	if (installType == tr("USB Drive"))
 	{
 #ifndef Q_OS_MAC
-		rebootmsgtext->setText(tr("After rebooting, select the USB boot option in the BIOS boot menu.%1\nReboot now?").arg(postinstmsg));
+		rebootmsgtext->setText(tr("After rebooting, select the USB boot option in the BIOS boot menu.%1").arg(postinstmsg));
 #endif
 #ifdef Q_OS_MAC
 		rebootmsgtext->setText(tr("The created USB device will not boot off a Mac. Insert it into a PC, and select the USB boot option in the BIOS boot menu.%1").arg(postinstmsg));
-		this->frebootbutton->setEnabled(false);
-		this->frebootbutton->hide();
 #endif
 	}
     finishLogging();

--- a/src/unetbootin/unetbootin.h
+++ b/src/unetbootin/unetbootin.h
@@ -349,7 +349,6 @@ private slots:
 	void on_InitrdFileSelector_clicked();
 	void on_CfgFileSelector_clicked();
 	void on_cancelbutton_clicked();
-	void on_frebootbutton_clicked();
 	void on_fexitbutton_clicked();
 
 public slots:

--- a/src/unetbootin/unetbootin.h
+++ b/src/unetbootin/unetbootin.h
@@ -287,7 +287,6 @@ public:
 	QPair<QString, int> weightedFilterNetDir(QString ldfDirStringUrl, int ldfMinSize, int ldfMaxSize, QList<QRegExp> ldfFileMatchExp);
 	QString fileFilterNetDir(QStringList ldfDirStringUrlList, int ldfMinSize, int ldfMaxSize, QList<QRegExp> ldfFileMatchExp);
 	QPair<QString, int> filterBestMatch(QStringList ufStringList, QList<QRegExp> filterExpList);
-	void sysreboot();
 	static QString callexternapp(QString xexecFile, QString xexecParm);
 	static QString callexternappWriteToStdin(QString xexecFile, QString xexecParm, QString xwriteToStdin);
 	QString getdevluid(QString voldrive);

--- a/src/unetbootin/unetbootin.ui
+++ b/src/unetbootin/unetbootin.ui
@@ -556,13 +556,6 @@
             <number>300</number>
            </property>
            <item>
-            <widget class="QPushButton" name="frebootbutton">
-             <property name="text">
-              <string>Reboot Now</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QPushButton" name="fexitbutton">
              <property name="text">
               <string>Exit</string>
@@ -678,7 +671,7 @@
         <item>
          <widget class="QLabel" name="sdesc4">
           <property name="text">
-           <string>4. Installation Complete, Reboot</string>
+           <string>4. Installation Complete</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
It is typical user case to use one computer for preparing USB for booting another computer.
Some cases user indeed want to reboot the very same computer, but systems have easy way to do that by itself.