### PR TITLE
Fix for issue 86 - allow unetbootin to detect FAT32 disks without naming them "FAT"

### DIFF
--- a/src/unetbootin/unetbootin.cpp
+++ b/src/unetbootin/unetbootin.cpp
@@ -658,8 +658,8 @@ QRegExp fatfilesystems("FAT|Microsoft");
 
 for (int i = 0; i < filesystemlist.size(); ++i)
 {
-	if (fatfilesystems.indexIn(filesystemlist.at(i),0) != -1) && is_external_drive_macos(usbdevsL.at(i))) {
-		fulldrivelist.append("/dev/"+usbdevsL.at(i));
+	if ((fatfilesystems.indexIn(filesystemlist.at(i),0) != -1) && is_external_drive_macos(drivenamelist.at(i))) {
+		fulldrivelist.append("/dev/"+drivenamelist.at(i));
 	}
 }
 #endif

--- a/src/unetbootin/unetbootin.h
+++ b/src/unetbootin/unetbootin.h
@@ -299,6 +299,7 @@ public:
 #endif
 	void refreshdriveslist();
 	QStringList listcurdrives();
+	QStringList matchinglist(QRegExp regex, QString text);
 	QStringList listsanedrives();
 	QStringList listalldrives();
 	void replaceTextInFile(QString repfilepath, QRegExp replaceme, QString replacewith);


### PR DESCRIPTION
Modified the Mac OSX portion of the listsanedrives() method to use the command "system_profiler SPStorageDataType" instead of "diskutil list", which is advantageous because the new command is formatted a bit better to allow better parsing of the file system type, especially when there are no partitions detected on the drive. The new result looks a bit like this:

>     Lexar:
> 
>       Available: 2.51 GB (2,509,144,064 bytes)
>       Capacity: 16 GB (16,000,188,416 bytes)
>       Mount Point: /Volumes/Lexar
>       File System: MS-DOS FAT32
>       Writable: Yes
>       Ignore Ownership: Yes
>       BSD Name: disk5s1
>       Volume UUID: C0F69EDD-E3D5-3142-B9C4-272FE160CC55
>       Physical Drive:
>           Device Name: USB Flash Drive
>           Media Name: Lexar USB Flash Drive Media
>           Protocol: USB
>           Internal: No
>           Partition Map Type: MBR (Master Boot Record)

Per @artur-pub, also added a failsafe in case "External" doesn't appear in the result of the "diskutil info" command.