### PR TITLE
Update Fedora support

### DIFF
--- a/src/unetbootin/distrolst.cpp
+++ b/src/unetbootin/distrolst.cpp
@@ -376,26 +376,22 @@ if (nameDistro == "Elive")
 
 if (nameDistro == "Fedora")
 {
-    QString minorarch = "";
 	if (isarch64)
 	{
 		cpuarch = "x86_64";
-        minorarch = "x86_64";
 	}
 	else
 	{
 		cpuarch = "i386";
-        minorarch = "i686";
 	}
 	if (islivecd)
 	{
         downloadfile(fileFilterNetDir(QStringList() <<
-        "http://download.fedoraproject.org/pub/fedora/linux/releases/"+relname+"/Live/"+cpuarch+"/"
+        "http://download.fedoraproject.org/pub/fedora/linux/releases/"+relname+"/Workstation/"+cpuarch+"/iso/"
         , 524288000, 2233125376, QList<QRegExp>() <<
         QRegExp(".iso$", Qt::CaseInsensitive) <<
         QRegExp("Fedora", Qt::CaseInsensitive) <<
-        QRegExp("Live", Qt::CaseInsensitive) <<
-        QRegExp("LXDE", Qt::CaseInsensitive)
+        QRegExp("Live", Qt::CaseInsensitive)
         ), isotmpf);
         extractiso(isotmpf);
 	}
@@ -403,15 +399,15 @@ if (nameDistro == "Fedora")
 	{
 		if (relname == "rawhide")
 		{
-            downloadfile(QString("download.fedoraproject.org/pub/fedora/linux/development/%1/os/images/pxeboot/vmlinuz").arg(cpuarch), QString("%1ubnkern").arg(targetPath));
-            downloadfile(QString("download.fedoraproject.org/pub/fedora/linux/development/%1/os/images/pxeboot/initrd.img").arg(cpuarch), QString("%1ubninit").arg(targetPath));
-			postinstmsg = unetbootin::tr("\n*IMPORTANT* After rebooting, ignore any error messages and select back if prompted for a CD, then go to the main menu, select the 'Start Installation' option, choose 'Network' as the source, choose 'HTTP' as the protocol, enter 'download.fedora.redhat.com' when prompted for a server, and enter '/pub/fedora/linux/development/%1/os' when asked for the folder.").arg(cpuarch);
+            downloadfile(QString("download.fedoraproject.org/pub/fedora/linux/development/rawhide/Workstation/%1/os/images/pxeboot/vmlinuz").arg(cpuarch), QString("%1ubnkern").arg(targetPath));
+            downloadfile(QString("download.fedoraproject.org/pub/fedora/linux/development/rawhide/Workstation/%1/os/images/pxeboot/initrd.img").arg(cpuarch), QString("%1ubninit").arg(targetPath));
+			postinstmsg = unetbootin::tr("\n*IMPORTANT* After rebooting, ignore any error messages and select back if prompted for a CD, then go to the main menu, select the 'Start Installation' option, choose 'Network' as the source, choose 'HTTP' as the protocol, enter 'download.fedoraproject.org' when prompted for a server, and enter '/pub/fedora/linux/development/rawhide/Workstation/%1/os' when asked for the folder.").arg(cpuarch);
         }
 		else
 		{
-            downloadfile(QString("http://download.fedoraproject.org/pub/fedora/linux/releases/%1/Fedora/%2/os/images/pxeboot/vmlinuz").arg(relname, cpuarch), QString("%1ubnkern").arg(targetPath));
-            downloadfile(QString("http://download.fedoraproject.org/pub/fedora/linux/releases/%1/Fedora/%2/os/images/pxeboot/initrd.img").arg(relname, cpuarch), QString("%1ubninit").arg(targetPath));
-			postinstmsg = unetbootin::tr("\n*IMPORTANT* After rebooting, ignore any error messages and select back if prompted for a CD, then go to the main menu, select the 'Start Installation' option, choose 'Network' as the source, choose 'HTTP' as the protocol, enter 'download.fedora.redhat.com' when prompted for a server, and enter '/pub/fedora/linux/releases/%1/Fedora/%2/os' when asked for the folder.").arg(relname, cpuarch);
+            downloadfile(QString("http://download.fedoraproject.org/pub/fedora/linux/releases/%1/Workstation/%2/os/images/pxeboot/vmlinuz").arg(relname, cpuarch), QString("%1ubnkern").arg(targetPath));
+            downloadfile(QString("http://download.fedoraproject.org/pub/fedora/linux/releases/%1/Workstation/%2/os/images/pxeboot/initrd.img").arg(relname, cpuarch), QString("%1ubninit").arg(targetPath));
+			postinstmsg = unetbootin::tr("\n*IMPORTANT* After rebooting, ignore any error messages and select back if prompted for a CD, then go to the main menu, select the 'Start Installation' option, choose 'Network' as the source, choose 'HTTP' as the protocol, enter 'download.fedoraproject.org' when prompted for a server, and enter '/pub/fedora/linux/releases/%1/Workstation/%2/os' when asked for the folder.").arg(relname, cpuarch);
 		}
 		kernelOpts = "splash=silent showopts";
 	}

--- a/src/unetbootin/distrover.cpp
+++ b/src/unetbootin/distrover.cpp
@@ -69,7 +69,7 @@ unetbootin::tr("<b>Homepage:</b> <a href=\"http://www.elivecd.org/\">http://www.
 	"<b>Description:</b> Elive is a Debian-based distribution featuring the Enlightenment window manager.<br/>"
 	"<b>Install Notes:</b> The Live version allows for booting in Live mode, from which the installer can optionally be launched.") <<
 "Stable_Live"));
-distroselect->addItem("Fedora", (QStringList() << "25_Live" <<
+distroselect->addItem("Fedora", (QStringList() << "26_Live" <<
 unetbootin::tr("<b>Homepage:</b> <a href=\"http://fedoraproject.org/\">http://fedoraproject.org</a><br/>"
 	"<b>Description:</b> Fedora is a Red Hat sponsored community distribution which showcases the latest cutting-edge free/open-source software.<br/>"
 	"<b>Install Notes:</b> The Live version allows for booting in Live mode, from which the installer can optionally be launched. The NetInstall version allows for both installation over the internet (FTP), or offline installation using pre-downloaded installation ISO files.") <<

--- a/src/unetbootin/distrover.cpp
+++ b/src/unetbootin/distrover.cpp
@@ -69,11 +69,11 @@ unetbootin::tr("<b>Homepage:</b> <a href=\"http://www.elivecd.org/\">http://www.
 	"<b>Description:</b> Elive is a Debian-based distribution featuring the Enlightenment window manager.<br/>"
 	"<b>Install Notes:</b> The Live version allows for booting in Live mode, from which the installer can optionally be launched.") <<
 "Stable_Live"));
-distroselect->addItem("Fedora", (QStringList() << "22_Live" <<
+distroselect->addItem("Fedora", (QStringList() << "25_Live" <<
 unetbootin::tr("<b>Homepage:</b> <a href=\"http://fedoraproject.org/\">http://fedoraproject.org</a><br/>"
 	"<b>Description:</b> Fedora is a Red Hat sponsored community distribution which showcases the latest cutting-edge free/open-source software.<br/>"
 	"<b>Install Notes:</b> The Live version allows for booting in Live mode, from which the installer can optionally be launched. The NetInstall version allows for both installation over the internet (FTP), or offline installation using pre-downloaded installation ISO files.") <<
-    "21_NetInstall" << "21_NetInstall_x64" << "21_Live" << "21_Live_x64" << "22_NetInstall" << "22_NetInstall_x64" << "22_Live" << "22_Live_x64" << "Rawhide_NetInstall" << "Rawhide_NetInstall_x64"));
+    "24_NetInstall" << "24_NetInstall_x64" << "24_Live" << "24_Live_x64" << "25_NetInstall" << "25_NetInstall_x64" << "25_Live" << "25_Live_x64" << "Rawhide_NetInstall" << "Rawhide_NetInstall_x64"));
 distroselect->addItem("FreeBSD", (QStringList() << "8.0" <<
 unetbootin::tr("<b>Homepage:</b> <a href=\"http://www.freebsd.org/\">http://www.freebsd.org</a><br/>"
 	"<b>Description:</b> FreeBSD is a general-purpose Unix-like operating system designed for scalability and performance.<br/>"

--- a/src/unetbootin/distrover.cpp
+++ b/src/unetbootin/distrover.cpp
@@ -73,7 +73,7 @@ distroselect->addItem("Fedora", (QStringList() << "25_Live" <<
 unetbootin::tr("<b>Homepage:</b> <a href=\"http://fedoraproject.org/\">http://fedoraproject.org</a><br/>"
 	"<b>Description:</b> Fedora is a Red Hat sponsored community distribution which showcases the latest cutting-edge free/open-source software.<br/>"
 	"<b>Install Notes:</b> The Live version allows for booting in Live mode, from which the installer can optionally be launched. The NetInstall version allows for both installation over the internet (FTP), or offline installation using pre-downloaded installation ISO files.") <<
-    "24_NetInstall" << "24_NetInstall_x64" << "24_Live" << "24_Live_x64" << "25_NetInstall" << "25_NetInstall_x64" << "25_Live" << "25_Live_x64" << "Rawhide_NetInstall" << "Rawhide_NetInstall_x64"));
+    "24_NetInstall" << "24_NetInstall_x64" << "24_Live" << "24_Live_x64" << "25_NetInstall" << "25_NetInstall_x64" << "25_Live" << "25_Live_x64" << "26_NetInstall" << "26_NetInstall_x64" << "26_Live" << "26_Live_x64" << "Rawhide_NetInstall" << "Rawhide_NetInstall_x64"));
 distroselect->addItem("FreeBSD", (QStringList() << "8.0" <<
 unetbootin::tr("<b>Homepage:</b> <a href=\"http://www.freebsd.org/\">http://www.freebsd.org</a><br/>"
 	"<b>Description:</b> FreeBSD is a general-purpose Unix-like operating system designed for scalability and performance.<br/>"


### PR DESCRIPTION
I refreshed the Fedora options offered by unetbootin to the current (and future, potentially) releases, since the versions previously offered are so old that they've been removed from some official mirrors. Along the way I corrected some bugs and URL/hostname issues that would've caused many of the offered versions to fail, anyway.

I did this in three commits, to make it easy to accept/reject whatever parts the maintainer sees fit. The first chunk does the major modernization and cleanup, offering Fedora 24 and 25 (the current release) along with the Rawhide development tree. That one's applicable ASAP.

The other two chunks first add support for Fedora 26, and then make it the default option. Fedora 26 will be out very soon (the release is scheduled and expected for next Tuesday, 2017-07-11), but until then the Fedora 26 options here will not work. So, one or both of those commits may want to be held back until then.