### PR TITLE
Logging to text file

### DIFF
--- a/src/unetbootin/UbUtilities.cpp
+++ b/src/unetbootin/UbUtilities.cpp
@@ -1,0 +1,246 @@
+/*********************************************
+	 Utilities 
+
+	
+*********************************************/
+
+
+
+#include "UbUtilities.h"
+#include <QFile>
+ #include <QDir>
+#include <QtGlobal>
+#include <QtDebug>
+
+// Initialization for static members:
+bool UbUtilities::isInitialized = false;
+UbUtilities* UbUtilities::_instance = 0;
+ 
+using namespace std;
+
+
+//CB>-------------------------------------------------------------------
+// 
+//  DESCRIPTION:  initClass
+//                    
+//  PRECONDITIONS: 
+//                 
+//  PARAMETER:
+//      IN:     
+//      OUT:    
+//
+//  RETURN:           
+
+//  SideFX:     
+//
+//<CE
+int UbUtilities::initClass (void) 
+{ 
+    if (isInitialized)
+        return 1;
+
+    isInitialized = true;
+    _instance = new UbUtilities();
+    //	AssertExp (_instance);
+
+    //  	_instance->setLoggingIsActive (false);
+    _instance->defaultFileName = "/Users/stefan2/unetbootinLog.txt";
+    std::string home = QDir::home().filePath("unetbootinLog.txt").toStdString();
+    qDebug() << "home: " << home.c_str();
+    //  	_instance->defaultFlags = _instance->logStream.flags();
+    std::ostream freshStream(0);
+
+    _instance->defaultFlags = freshStream.flags();
+    _instance->defaultFlags |= ios_base::dec;
+
+    _instance->openFileIfNecessary();
+    //	setLogMode (UbUtilities::noLogMode);
+    qInstallMsgHandler( writeLogMsgToFile );
+
+    qDebug() << "UbUtilities::initClass (void)  called";
+    qDebug() << "home: " << home.c_str();
+
+    return 0;
+}
+
+void UbUtilities::writeLogMsgToFile (QtMsgType type, const char *msg)
+{
+    switch (type) {
+    case QtDebugMsg:
+    case QtWarningMsg:
+    case QtCriticalMsg:
+    case QtFatalMsg:
+        // fprintf(stderr, "Debug: %s\n", msg);
+  //      _instance->logStream.write( , strlen(msg) );
+        _instance->logStream << msg << std::endl << std::flush;
+      //  _instance->logStream.flush();
+        break;
+        //        fprintf(stderr, "Warning: %s\n", msg);
+        //        break;
+        //        fprintf(stderr, "Critical: %s\n", msg);
+        //        break;
+        //        fprintf(stderr, "Fatal: %s\n", msg);
+        //        abort();
+    }
+}
+
+//CB>-------------------------------------------------------------------
+// 
+//  DESCRIPTION:  shutdownClass
+//                    
+//  PRECONDITIONS: 
+//                 
+//  PARAMETER:
+//      IN:     
+//      OUT:    
+//
+//  RETURN:           
+
+//  SideFX:     
+//
+//<CE
+void UbUtilities::shutdownClass() 
+{ 
+		if (_instance) {
+			delete _instance;
+			_instance = 0;
+		}
+		isInitialized = false;
+}
+
+//CB>-------------------------------------------------------------------
+// 
+//  DESCRIPTION:  openFileIfNecessary
+//                    
+//<CE
+void UbUtilities::openFileIfNecessary (void) 
+{
+	if (_instance->ourStreamBuf.is_open())
+		return;
+
+	// determine a valid file name
+	string fileName;
+	if (_instance->validFileName.empty() )
+		fileName = _instance->defaultFileName;
+	else
+		fileName = _instance->validFileName;
+	
+	// check if file is writeable	
+	determinePossibleFileName (fileName);
+	// AssertExp (!_instance->validFileName.empty());
+	_instance->validFileName = fileName;
+	
+	// _instance->ourStreamBuf.open (_instance->validFileName.c_str(), ios::in | ios::out  ); // | ios::app
+	_instance->ourStreamBuf.open (_instance->validFileName.c_str(), ios::out | ios::app  ); // | ios::app
+//	AssertExp (_instance->ourStreamBuf.is_open());
+	if (!_instance->ourStreamBuf.is_open()) {
+	  // stw 2005-07-04 UbUtilities::setLoggingIsActive (false); // something went wrong, dont try to write
+	}
+    _instance->logStream.rdbuf (&_instance->ourStreamBuf);
+	return ;
+}
+
+//CB>-------------------------------------------------------------------
+// 
+//  DESCRIPTION:  
+//                    
+//<CE
+//void UbUtilities::setLoggingIsActive (bool value)
+//{
+//	if (!isInitialized)
+//		UbUtilities::initClass();
+//	if (value == true && _instance->loggingIsActive == false) {
+//		// init
+////		UbUtilities::setLogMode (UbUtilities::logFileMode);
+//	}
+//	_instance->loggingIsActive = value;
+//}
+
+//CB>-------------------------------------------------------------------
+// 
+//  DESCRIPTION:  
+//                    
+//<CE
+bool UbUtilities::getLoggingIsActive (void)  
+{ 
+	if (!isInitialized)
+		UbUtilities::initClass();
+	return UbUtilities::_instance->loggingIsActive; 
+}
+
+//CB>-------------------------------------------------------------------
+// 
+//  DESCRIPTION:  
+//                    
+//<CE
+UbUtilities* UbUtilities::getInstance (void) 
+{ 
+	if (!isInitialized)
+		UbUtilities::initClass();
+	return _instance; 
+}
+
+//CB>-------------------------------------------------------------------
+// 
+//  DESCRIPTION:  
+//                    
+//<CE
+void UbUtilities::setDefaultFileName (string& value) 
+{ 
+	if (!isInitialized)
+		UbUtilities::initClass();
+		
+	_instance->defaultFileName = value; 
+}
+
+//CB>-------------------------------------------------------------------
+// 
+//  DESCRIPTION:  determinePossibleFileName
+//                    
+//<CE
+string& UbUtilities::determinePossibleFileName (string& fileName ) 
+{
+	string testFileName, savedFileName;
+	testFileName = fileName;
+	savedFileName = fileName;
+	// create a new name if open failed by appending a number.
+	 int aNumber = 1;
+	 bool success = false;
+	//	 string newFileName;
+	FILE* testFile = 0;
+	// try if file exists and is writeable
+	testFile = fopen (testFileName.c_str(), "r+"); // was "w" which caused truncation of file
+	
+	if (testFile != 0) {  
+	// file exists and is writeable
+		fclose (testFile);
+		return fileName;
+	}
+//	else {
+	// try if a new file with this name can be created
+	testFile = fopen (testFileName.c_str(), "w"); 
+	if (testFile != 0) {  
+	// file has beed created (with 0 bytes)
+		fclose (testFile);
+		return fileName;
+	}
+	// find a new filename by appending a number at the end of the file name	
+	do {
+		ostringstream aStream;
+	 	string numberString;
+	 	aStream << aNumber << ends;
+	 	numberString = aStream.str();
+	 	testFileName = savedFileName + numberString;
+		testFile = fopen (testFileName.c_str(), "w");
+	 	success = (testFile != 0);
+	 	if (success) {
+			fclose (testFile);
+			fileName = testFileName;
+		}
+	 	aNumber ++;
+	 	if (aNumber > 200)
+	 		break;
+	 } while (!success);
+	 
+	return fileName;
+}

--- a/src/unetbootin/UbUtilities.cpp
+++ b/src/unetbootin/UbUtilities.cpp
@@ -1,6 +1,29 @@
 /*********************************************
 	 Utilities 
 
+Decription:
+Contains logging to file ($HOME/„unetbootinLog.txt“) based on the Qt debugging facility:
+Usage:
+#include <qapplication.h>
+
+qWarning() << „some message“ << someObject;
+
+See QT documentation: e.g.: Both qDebug() and qWarning() are debugging tools. They can be compiled away by defining QT_NO_DEBUG_OUTPUT and QT_NO_WARNING_OUTPUT during compilation.
+The debugging functions QObject::dumpObjectTree() and QObject::dumpObjectInfo() are often useful when an application looks or acts strangely. More useful if you use object names than not, but often useful even without names.
+I use qWarning() because qDebug() is compiled away by QT_NO_DEBUG_OUTPUT which is in the Makefile;
+The code is not release ready! We have to decide following questions:
+* Do we want logging always be active?
+* Where do we want the logging file to reside?
+* Do we want to always start a new file or use an existing old one?
+* How many old log files do we want to keep?
+
+Other questions:
+* How can we output the actual version of unetbootin?
+* How could we implement a version check mechanism for unetbootin?
+
+Todo:
+* log stderr and stdout in callExternApp()
+
 	
 *********************************************/
 

--- a/src/unetbootin/UbUtilities.h
+++ b/src/unetbootin/UbUtilities.h
@@ -47,35 +47,36 @@ public:
 //	  logMode = noLogMode;
 	};
 
-	~UbUtilities (void) { ourStreamBuf.close(); };
+        ~UbUtilities (void) { ourStreamBuf.close(); };
 
-	static int initClass (void) ;
+        static int initClass (void) ;
 
-	static void shutdownClass() ;
-	
-	static std::ostream& getLogStream(void);
+        static void shutdownClass() ;
 
-	static std::string& getDateTimeString(void) ;
-	
-	static void setLoggingIsActive (bool value);
-	
-	static bool getLoggingIsActive (void) ;
+        static std::ostream& getLogStream(void);
 
-	static void openFileIfNecessary();
-	
-//	static void closeFileIfNecessary();
-	
-  // static void writeLog (void);
-	
-	static void setDefaultFileName (std::string& value);
-	
-//	static void setLogMode (LogMode logModeValue);
-	
-	static std::string& determinePossibleFileName (std::string& fileName ) ;
-	static std::ios_base::fmtflags getDefaultFlags (void) {return _instance->defaultFlags; }
-  static UbUtilities* getInstance (void) ;
-  static void writeLogMsgToFile (QtMsgType type, const char *msg);
+        static std::string& getDateTimeString(void) ;
 
+        static void setLoggingIsActive (bool value);
+
+        static bool getLoggingIsActive (void) ;
+
+        static void openFileIfNecessary();
+
+        //	static void closeFileIfNecessary();
+
+        // static void writeLog (void);
+
+        static void setDefaultFileName (std::string& value);
+
+        //	static void setLogMode (LogMode logModeValue);
+
+        static std::string& determinePossibleFileName (std::string& fileName ) ;
+        static std::ios_base::fmtflags getDefaultFlags (void) {return _instance->defaultFlags; }
+        static UbUtilities* getInstance (void) ;
+        static void writeLogMsgToFile (QtMsgType type, const char *msg);
+        static void logSystemInfo (void);
+        static QString getOsName (void);
 
 };
 

--- a/src/unetbootin/UbUtilities.h
+++ b/src/unetbootin/UbUtilities.h
@@ -1,0 +1,84 @@
+/*********************************************
+	 Utilities 
+
+	
+*********************************************/
+// to switch off Logging call ::setLoggingIsActive (false);
+
+#ifndef UBUTILITIES_H
+#define UBUTILITIES_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#ifdef __cplusplus  // make it compatible for C-Files
+
+#include <iostream>
+#include <ios>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <qapplication.h> // for qt logging
+
+using namespace std;
+
+class UbUtilities 
+{
+public:
+  
+private:
+	static UbUtilities* _instance;
+	static bool isInitialized;
+	std::ostream logStream;
+	std::string validFileName;
+	bool loggingIsActive;
+	std::string defaultFileName;
+	std::ios_base::fmtflags defaultFlags;
+	std::string dateTimeString;
+//	LogMode logMode;
+	std::filebuf ourStreamBuf;
+#ifdef SYSLOG_AVAILABLE
+	SysLogBuf ourSysLogBuf;
+#endif
+
+public:
+
+	UbUtilities (void) : logStream (0) {
+	  loggingIsActive = true;
+//	  logMode = noLogMode;
+	};
+
+	~UbUtilities (void) { ourStreamBuf.close(); };
+
+	static int initClass (void) ;
+
+	static void shutdownClass() ;
+	
+	static std::ostream& getLogStream(void);
+
+	static std::string& getDateTimeString(void) ;
+	
+	static void setLoggingIsActive (bool value);
+	
+	static bool getLoggingIsActive (void) ;
+
+	static void openFileIfNecessary();
+	
+//	static void closeFileIfNecessary();
+	
+  // static void writeLog (void);
+	
+	static void setDefaultFileName (std::string& value);
+	
+//	static void setLogMode (LogMode logModeValue);
+	
+	static std::string& determinePossibleFileName (std::string& fileName ) ;
+	static std::ios_base::fmtflags getDefaultFlags (void) {return _instance->defaultFlags; }
+  static UbUtilities* getInstance (void) ;
+  static void writeLogMsgToFile (QtMsgType type, const char *msg);
+
+
+};
+
+#endif // #ifdef __cplusplus
+
+#endif //#define UBUTILITIES_Hm

--- a/src/unetbootin/unetbootin.cpp
+++ b/src/unetbootin/unetbootin.cpp
@@ -69,7 +69,7 @@ static const QString SALT_DETECTED = "*SaLT*";
 
 void callexternappT::run()
 {
-    qDebug() << "callexternappT::run() called; execFile: " << execFile <<"; execParm:"<<execParm<<"; ";
+    qWarning() << "callexternappT::run() called; execFile: " << execFile <<"; execParm:"<<execParm<<"; ";
 	#ifdef Q_OS_WIN32
     SHELLEXECUTEINFO ShExecInfo = {0};
 	ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
@@ -98,10 +98,6 @@ void callexternappT::run()
 	lnexternapp.waitForFinished(-1);
 	retnValu = QString(lnexternapp.readAll());
 	#endif
-//#ifdef Q_OS_MAC
-//    qDebug() << "callexternappT::run() called; no action or code on MacOS!";
-
-//#endif
 
 }
 
@@ -793,7 +789,7 @@ void unetbootin::on_cancelbutton_clicked()
 
 void unetbootin::on_okbutton_clicked()
 {
-    qDebug() << "on_okbutton_clicked()";
+    qWarning() << "on_okbutton_clicked()";
     if (typeselect->currentIndex() == typeselect->findText(tr("USB Drive")) && driveselect->currentText().isEmpty() && !testingDownload)
 	{
 		QMessageBox unotenoughinputmsgb;
@@ -3603,6 +3599,7 @@ void unetbootin::runinst()
 	}
 	else if (radioManual->isChecked())
 	{
+        qWarning() << "runinst() " <<"targetPath: " << targetPath<< "; KernelPath: " << KernelPath ;
 		if (!KernelPath->text().startsWith("http://") && !KernelPath->text().startsWith("ftp://"))
 			QFile::copy(KernelPath->text(), QString("%1ubnkern").arg(targetPath));
 		else
@@ -3617,7 +3614,9 @@ void unetbootin::runinst()
 	{
 		nameDistro = distroselect->currentText();
 		nameVersion = dverselect->currentText();
-		if (nameVersion.contains("_Live"))
+        qWarning() << "runinst() " <<"targetPath: " << targetPath<< "; KernelPath: " << KernelPath << "; nameDistro: "<< nameDistro
+                   << "; nameVersion" << nameVersion;
+        if (nameVersion.contains("_Live"))
 		{
 			nameVersion.remove("_Live");
 			islivecd = true;

--- a/src/unetbootin/unetbootin.cpp
+++ b/src/unetbootin/unetbootin.cpp
@@ -8,6 +8,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 */
 
 #include "unetbootin.h"
+#include "UbUtilities.h"
 
 static const QList<QRegExp> ignoredtypesbothRL = QList<QRegExp>()
 << QRegExp("isolinux.bin$", Qt::CaseInsensitive)
@@ -68,8 +69,9 @@ static const QString SALT_DETECTED = "*SaLT*";
 
 void callexternappT::run()
 {
+    qDebug() << "callexternappT::run() called; execFile: " << execFile <<"; execParm:"<<execParm<<"; ";
 	#ifdef Q_OS_WIN32
-	SHELLEXECUTEINFO ShExecInfo = {0};
+    SHELLEXECUTEINFO ShExecInfo = {0};
 	ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
 	ShExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
 	ShExecInfo.hwnd = NULL;
@@ -91,11 +93,16 @@ void callexternappT::run()
 	retnValu = "";
 	#endif
 	#ifdef Q_OS_UNIX
-	QProcess lnexternapp;
+    QProcess lnexternapp;
     lnexternapp.start("\"" + execFile + "\" " + execParm);
 	lnexternapp.waitForFinished(-1);
 	retnValu = QString(lnexternapp.readAll());
 	#endif
+//#ifdef Q_OS_MAC
+//    qDebug() << "callexternappT::run() called; no action or code on MacOS!";
+
+//#endif
+
 }
 
 void callexternappWriteToStdinT::run()
@@ -178,6 +185,7 @@ unetbootin::unetbootin(QWidget *parent)
 	setupUi(this);
 }
 
+
 bool unetbootin::ubninitialize(QList<QPair<QString, QString> > oppairs)
 {
     skipExtraction = false;
@@ -194,8 +202,7 @@ bool unetbootin::ubninitialize(QList<QPair<QString, QString> > oppairs)
 	testingDownload = false;
 	issalt = false;
 	persistenceSpaceMB = 0;
-    logFile = 0;
-    logStream = 0;
+    UbUtilities::initClass () ; // init logging
 #ifdef Q_OS_MAC
 	ignoreoutofspace = true;
 #endif
@@ -780,11 +787,13 @@ void unetbootin::on_CfgFileSelector_clicked()
 
 void unetbootin::on_cancelbutton_clicked()
 {
-	close();
+    UbUtilities::shutdownClass() ; // flush logging
+    close();
 }
 
 void unetbootin::on_okbutton_clicked()
 {
+    qDebug() << "on_okbutton_clicked()";
     if (typeselect->currentIndex() == typeselect->findText(tr("USB Drive")) && driveselect->currentText().isEmpty() && !testingDownload)
 	{
 		QMessageBox unotenoughinputmsgb;
@@ -4048,37 +4057,6 @@ QString unetbootin::fixkernelbootoptions(const QString &cfgfileCL)
 	.trimmed();
 }
 
-void unetbootin::logText(const QString &text)
-{
-    return;
-    /*
-    if (targetPath.isNull() || targetPath.isEmpty())
-    {
-        loggedLinesNotYetWritten.append(text);
-        return;
-    }
-    if (logStream == 0)
-    {
-        logFile = new QFile(QString("%1unetbootin-log.txt").arg(targetPath));
-        logFile->open(QIODevice::WriteOnly | QIODevice::Text);
-        logStream = new QTextStream(logFile);
-        for (int i = 0; i < loggedLinesNotYetWritten.size(); ++i)
-        {
-            *logStream << loggedLinesNotYetWritten.at(i) << endl;
-        }
-        loggedLinesNotYetWritten.clear();
-    }
-    *logStream << text << endl;
-    */
-}
-
-void unetbootin::finishLogging()
-{
-    if (logFile != 0)
-    {
-        logFile->close();
-    }
-}
 
 void unetbootin::writeTextToFile(const QString &text, const QString &filePath)
 {
@@ -4286,6 +4264,8 @@ void unetbootin::runinstusb()
 
 void unetbootin::killApplication()
 {
+    UbUtilities::shutdownClass() ; // flush logging
+
 	exit(0);
 }
 
@@ -4354,7 +4334,7 @@ void unetbootin::fininstall()
 		rebootmsgtext->setText(tr("The created USB device will not boot off a Mac. Insert it into a PC, and select the USB boot option in the BIOS boot menu.%1").arg(postinstmsg));
 #endif
 	}
-    finishLogging();
+    UbUtilities::shutdownClass(); // finish logging
 	if (exitOnCompletion)
 	{
 		printf("exitstatus:success\n");

--- a/src/unetbootin/unetbootin.h
+++ b/src/unetbootin/unetbootin.h
@@ -14,7 +14,6 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 #include <QtGui>
 #include <QtNetwork>
 #include <time.h>
-//#include <QtDebug>
 
 #include "ui_unetbootin.h"
 
@@ -330,9 +329,7 @@ public:
 	#endif
 	void runinsthdd();
 	void runinstusb();
-    void logText(const QString &text);
-    void finishLogging();
-    void writeTextToFile(const QString &text, const QString &filePath);
+     void writeTextToFile(const QString &text, const QString &filePath);
 	void fininstall();
 	void rmFile(const QString &fn);
 	void rmFile(QFile &fn);

--- a/src/unetbootin/unetbootin.pro
+++ b/src/unetbootin/unetbootin.pro
@@ -11,7 +11,8 @@ SOURCES += main.cpp \
     unetbootin.cpp \
     distrolst.cpp \
     distrover.cpp \
-    distrovercust.cpp
+    distrovercust.cpp \
+    UbUtilities.cpp
 QT += core \
     gui \
     network


### PR DESCRIPTION
Decription:    
Contains logging to file ($HOME/„unetbootinLog.txt“) based on the Qt debugging facility:
Usage: 
#include <qapplication.h>

qWarning() << „some message“ << someObject;

See QT documentation: e.g.: Both qDebug() and qWarning() are debugging tools. They can be compiled away by defining QT_NO_DEBUG_OUTPUT and QT_NO_WARNING_OUTPUT during compilation.
The debugging functions QObject::dumpObjectTree() and QObject::dumpObjectInfo() are often useful when an application looks or acts strangely. More useful if you use object names than not, but often useful even without names.
I use qWarning() because qDebug() is compiled away by QT_NO_DEBUG_OUTPUT which is in the Makefile;
The code is not release ready! We have to decide following questions:
* Do we want logging always be active?
* Where do we want the logging file to reside? Log file name (hidden file name e.g.  .unetbootinLog.txt ?)
* Do we want to always start a new file or use an existing old one?
* How many old log files do we want to keep?

Other questions: 
* How can we output the actual version of unetbootin?
* How could we implement a version check mechanism for unetbootin?

Todo:
* log stderr and stdout in callExternApp()