### PR TITLE
Update deprecated SF compile links.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,11 +21,11 @@ https://github.com/unetbootin/unetbootin/issues
 
 ### Building
 
-https://sourceforge.net/p/unetbootin/wiki/compile/
+https://github.com/unetbootin/unetbootin/wiki/compile
 
 ### Contributing
 
-https://sourceforge.net/p/unetbootin/wiki/development/
+https://github.com/unetbootin/unetbootin/wiki/development
 
 ### Licence
 

--- a/src/unetbootin/INSTALL
+++ b/src/unetbootin/INSTALL
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # you will need "qmake" and "libqt4-dev" to build this
-# details at http://sourceforge.net/apps/trac/unetbootin/wiki/compile
+# details at https://github.com/unetbootin/unetbootin/wiki/compile
 
 cp unetbootin.pro unetbootin-pro.bak
 sed -i '/^RESOURCES/d' unetbootin.pro
@@ -10,4 +10,3 @@ lrelease unetbootin.pro
 qmake "DEFINES += NOSTATIC" "RESOURCES -= unetbootin.qrc"
 make
 mv unetbootin-pro.bak unetbootin.pro
-


### PR DESCRIPTION
Small PR to update the compilation links still pointing to SourceForge.

@gkovacs can you take a look?