### PR TITLE
Fix #214 - Inscrease persistent storage

### DIFF
--- a/src/unetbootin/unetbootin.ui
+++ b/src/unetbootin/unetbootin.ui
@@ -430,7 +430,7 @@
            <string>Space to reserve for user files which are preserved across reboots. Works only for LiveUSBs for Ubuntu and derivatives. If value exceeds drive capacity, the maximum space available will be used.</string>
           </property>
           <property name="maximum">
-           <number>9999</number>
+           <number>128000</number>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Fix [#214](https://github.com/unetbootin/unetbootin/issues/214) issue

> I am on a Windows 10 laptop. I just did an install of ubuntu-18.04.2-desktop-amd64.iso to a 32G USB flash drive.
> The install dialog allows maximum persistent storage of 9999, which I believe means 9.99G. Given that there are USB flash drives with capacity as high as 128G, please provide the option to fully utilize the available space on the flash drive for persistent storage.