### PR TITLE
Remove deprecated and untestable sudo helpers

### DIFF
--- a/src/unetbootin/unetbootin_asroot
+++ b/src/unetbootin/unetbootin_asroot
@@ -1,14 +1,6 @@
 #!/bin/bash
- 
-if hash gksu 2> /dev/null; then
-gksu env QT_X11_NO_MITSHM=1 unetbootin
-elif hash kdesu 2> /dev/null; then
-kdesu env QT_X11_NO_MITSHM=1 unetbootin
-elif hash gnomesudo 2> /dev/null; then
-gnomesudo env QT_X11_NO_MITSHM=1 unetbootin
-elif hash kdesudo 2> /dev/null; then
-kdesudo env QT_X11_NO_MITSHM=1 unetbootin
-elif hash pkexec 2> /dev/null; then
+
+if hash pkexec 2> /dev/null; then
 pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY QT_X11_NO_MITSHM=1 unetbootin
 else
 unetbootin


### PR DESCRIPTION
- `gksu` is deprecated and was removed after Ubuntu 18.04
- `kdesu` still technically exists but isn't in `$PATH` by default, at least on Ubuntu
- `gnomesudo` I couldn't find much info on, but looks to be a predecessor of `gksu`, therefore quite old/deprecated
- `kdesudo`was deprecated long ago (on some systems it was replaced with a symlink to `kdesu`)