### PR TITLE
Add basic Ubuntu CI to build the project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on: [push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+  PLATFORM: EEEUBUNTU # FIXME: This is just a placeholder. CMake does not respect this kind of defines yet
+
+jobs:
+  build_ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set Up Build Environment
+      working-directory: ${{github.workspace}}/src/unetbootin
+      shell: bash
+      run: |
+        sudo apt-get install -y build-essential cmake qtbase5-dev qttools5-dev
+        mkdir -p build_tmp
+
+    - name: Build UNetbootin
+      working-directory: ${{github.workspace}}/src/unetbootin/build_tmp
+      shell: bash
+      run: |
+        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPLATFORM=$PLATFORM
+        make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ env:
 
 jobs:
   build_ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
At the moment the build folder is called `build_tmp` as there is a shell script called `build` which causes the naming conflict. I will address this issue later by moving the scripts to a separate folder.