### PR TITLE
Update GitHub Actions env, replace EOL-ed Ubuntu 18.04 with 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This will fix the failed workflows here: https://github.com/unetbootin/unetbootin/actions

![image](https://github.com/unetbootin/unetbootin/assets/3691490/f6d39e9a-d09f-413a-98cf-778bbe125813)


Reference:

"GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22"
- https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/