### PR TITLE
Fix Linux Mint mirror syntax error

### DIFF
--- a/src/unetbootin/distrolst.cpp
+++ b/src/unetbootin/distrolst.cpp
@@ -629,7 +629,7 @@ if (nameDistro == "Linux Mint")
 	QString("http://www.mirrorservice.org/sites/www.linuxmint.com/pub/linuxmint.com/stable/%1/").arg(relname) <<
 	QString("http://ftp.icm.edu.pl/pub/Linux/dist/linuxmint/isos/stable/%1/").arg(relname) <<
 	QString("http://ftp.fau.de/mint/iso/stable/%1/").arg(relname) <<
-	QString("http://mirrors.ocf.berkeley.edu/linux-mint/stable/%1/").arg(relname) <<
+	QString("http://mirrors.ocf.berkeley.edu/linux-mint/stable/%1/").arg(relname) //<<
 //	QString("ftp://mirrors.secution.com/linuxmint.com/stable/%1/").arg(relname) <<
 //	QString("ftp://ftp.is.co.za/mirror/linuxmint.com/stable/%1/").arg(relname) <<
 //	QString("ftp://ftp.tpnet.pl/pub/linux/linuxmint/isos/stable/%1/").arg(relname) <<


### PR DESCRIPTION
Something broken in #363 😅 

Fix #363 / 6576db5f4615215ab1ba7e1d00a57aac8c958521